### PR TITLE
Typo. Update xy-linux-mac-install.sh

### DIFF
--- a/xy-linux-mac-install.sh
+++ b/xy-linux-mac-install.sh
@@ -2,4 +2,4 @@
 npm i
 
 chmod +x xy-linux-mac-install.sh
-./xy-linux-mac-insall.sh
+./xy-linux-mac-install.sh


### PR DESCRIPTION
The command fails to run because the filename has a typo. Fixed: insall -> install